### PR TITLE
Create CONTRIBUTING.md with documentation structure proposal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Content Structure
+The Hubs documentation site has several different types of content that covers both Hubs and Spoke. Please keep the following structure in mind when creating new documentation files for the site. 
+
+* Getting Started Guides
+  - Guide #1
+  - Guide #2
+* Hubs Reference
+  - (Example) User controls
+  - (Example) User list
+  - (Example) Object list 
+* Spoke Reference
+  - (Example) Asset Panel
+  - (Example) Element Properties
+* For Developers
+  - (Example) Source Code
+  - (Example) Contributing to Hubs and Spoke


### PR DESCRIPTION
As we get closer to go-live with documentation, we should align to a content structure that makes it clear where new content will live. This site will cover both Hubs and Spoke documentation, and we'll want to make it useful for audiences of end-users, room owners, content creators, and developers. 

This is a first attempt at a proposal, starting off a contributing file but I expect that this will grow to cover a greater scope. We may need to add and change categories, but wanted to get a starting point we could work from.