### PR TITLE
Remove search from live site

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -57,11 +57,11 @@ const siteConfig = {
     secondaryColor: '#ff3464',
   },
 
-  algolia: {
-    apiKey: '227afb429135813e4d9d2339ea8a18c7',
-    indexName: 'mozilla_hub',
-    algoliaOptions: {} // Optional, if provided by Algolia
-  },
+  // algolia: {
+  //   apiKey: '227afb429135813e4d9d2339ea8a18c7',
+  //   indexName: 'mozilla_hub',
+  //   algoliaOptions: {} // Optional, if provided by Algolia
+  // },
 
   /* Custom fonts for website */
   /*


### PR DESCRIPTION
CSP errors are thrown when the search is live. We don't have time to look at this right now, so removing it from the live site.

> 
Refused to load the script 'https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js' because it violates the following Content Security Policy directive: "script-src 'sha256-foB3G7vO68Ot8wctsG3OKBQ84ADKVinlnTg9/s93Ycs=' 'sha256-g0j42v3Wo/ohUAMR/t0EuObDSEkx1rZ3lv45fUaNmYs=' 'sha256-1bG69cjuJlQcoR2gPgfr+YdOzfYOv5vthSG0IUK6ANc=' https://buttons.github.io https://sentry.prod.mozaws.net https://assets-prod.reticulum.io https://smoke-assets-prod.reticulum.io https://asset-bundles-prod.reticulum.io https://smoke-asset-bundles-prod.reticulum.io https://cdn.rawgit.com https://uploads-prod.reticulum.io  'self' 'unsafe-eval' 'sha256-ViVvpb0oYlPAp7R8ZLxlNI6rsf7E7oz8l1SgCIXgMvM=' 'sha256-hsbRcgUBASABDq7qVGVTpbnWq/ns7B+ToTctZFJXYi8=' 'sha256-MIpWPgYj31kCgSUFc0UwHGQrV87W6N5ozotqfxxQG0w=' 'sha256-buF6N8Z4p2PuaaeRUjm7mxBpPNf4XlCT9Fep83YabbM=' 'sha256-/S6PM16MxkmUT7zJN2lkEKFgvXR7yL4Z8PCrRrFu4Q8=' https://www.google-analytics.com https://uploads-prod.reticulum.io  https://aframe.io https://www.youtube.com https://s.ytimg.com". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.