### PR TITLE
Centralized help page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ This website was created with [Docusaurus](https://docusaurus.io/).
 $ cd website
 
 # Install dependencies
-$ yarn
+$ npm ci
 ```
 2. Run your dev server:
 
 ```sh
 # Start the site
-$ yarn start
+$ npm start
 ```
 
 ### Directory Structure

--- a/docs/dev-contributing.md
+++ b/docs/dev-contributing.md
@@ -66,5 +66,5 @@ Our documentation for Hubs is hosted on the [GitHub Hubs Wiki](https://github.co
 Hubs is currently en-US only, but if you would like to work with us on localization efforts, submit a suggestion through the GitHub issues and we'll work with you from there. 
 
 ### 🦆 General Help
-We believe in the power of community (that's why we're building this, after all!) and know that not all forms of support will come from something outlined here. Feel free to jump into our public [Discord server](https://discord.gg/wHmY4nd) to chat with us and ask about how you can get involved!
+We believe in the power of community (that's why we're building this, after all!) and know that not all forms of support will come from something outlined here. Feel free to jump into our public [Discord chat server](https://discord.gg/wHmY4nd) to chat with us and ask about how you can get involved! See our [help page](./help.html) for other ways to contact us.
 

--- a/docs/dev-contributing.md
+++ b/docs/dev-contributing.md
@@ -19,7 +19,7 @@ The following GitHub projects are part of the Hubs platform and governed by thes
 
 ## Quick Start
 
-We are happy to receive contributions to the Hubs platform in a number of different ways as outlined below. Please note that all contributions are subject to approval by the project maintainers. We ask (but do not require) that those interested in contributing to Hubs consider joining the public [Hubs Discord server](https://discord.gg/wHmY4nd) to connect with the dev team, ask questions, and view discussions about work being done on the project. 
+We are happy to receive contributions to the Hubs platform in a number of different ways as outlined below. Please note that all contributions are subject to approval by the project maintainers. We ask (but do not require) that those interested in contributing to Hubs consider joining the public [Hubs Discord chat server](https://discord.gg/wHmY4nd) to connect with the dev team, ask questions, and view discussions about work being done on the project.
 
 ### 💻 Code Contributions
 Hubs has a client-server architecture that gives multiple users the ability to connect to a shared room on the server. If you are interested in contributing to the Hubs client, follow the instructions in the [Readme](README.md) to get started. If you want to contribute to the networking or infrastructure, consider looking at the [reticulum](https://github.com/mozilla/reticulum) or [janus](https://github.com/mozilla/janus-plugin-sfu) repositories. If you are interested in working on the code for Spoke, the 3D editor used to create custom environments for Hubs rooms, explore the [Spoke](https://github.com/mozilla/spoke) repository.

--- a/docs/hubs-cloud-aws-domain-recipes.md
+++ b/docs/hubs-cloud-aws-domain-recipes.md
@@ -112,4 +112,4 @@ To use an existing email provider, read through our [Using an Existing Email Pro
 2. Check AWS Console > Route 53 > [Hosted Zones](https://console.aws.amazon.com/route53/home#hosted-zones:) and all of the domains you listed above are [registered](https://console.aws.amazon.com/route53/home#DomainListing:) on Route 53 or you've updated the nameservers for your domains to point to AWS Route 53 as the DNS host
 3. Find the rollback error in the stack output for your region [AWS Troubleshooting: see first stack error event](./hubs-cloud-aws-troubleshooting.md#my-aws-stack-says-rollback-complete-after-deploying-what-went-wrong)
 4. Troubleshoot any common errors via [AWS Troubleshooting documentation](./hubs-cloud-aws-troubleshooting.md)
-5. Email hubs-support@mozilla.com for additional assistance
+5. If you can't find what you need in the rest of our documentation, see the [help page](./help.html) for ways to get in touch.

--- a/docs/hubs-cloud-aws-troubleshooting.md
+++ b/docs/hubs-cloud-aws-troubleshooting.md
@@ -142,4 +142,4 @@ Follow steps in [Check if you're on version 1.1.0](./hubs-cloud-aws-updating-the
 
 ## Missing a solution?
 
-Let us know! hubs@mozilla.com
+If you can't find what you need in the rest of the documentation, see the [help page](./help.html) for ways to get in touch.

--- a/docs/hubs-cloud-do-quick-start.md
+++ b/docs/hubs-cloud-do-quick-start.md
@@ -31,4 +31,4 @@ Hubs Cloud DigitalOcean can be found on [DigitalOcean Marketplace](https://marke
 8. Upon login the Hubs Cloud setup wizard will start automatically. This will guide you through all the rest of the steps required to get you Hubs Cloud instance up and running. If you ever need to change the settings you entered during setup or if you exited it for any other reason you can re-run it by running `/opt/polycosm/setup.sh`
     - You will need to provide a database or create a DigitalOcean Managed Database during setup. DigitalOcean Managed Databases start at $15/mo [See pricing for all DigitalOcean services here](https://www.digitalocean.com/pricing/).
 
-DigitalOcean is currently an **alpha** pre-release. Please report any issues to [Hubs Support](mailto:hubs@mozilla.com).
+DigitalOcean is currently an **alpha** pre-release. If you run into any issues, see the [help page](./help.html) for ways you can get in touch.

--- a/docs/hubs-cloud-faq.md
+++ b/docs/hubs-cloud-faq.md
@@ -65,6 +65,8 @@ See ["Check "What is my hubs stack's admin email address?" docs](./hubs-cloud-aw
 
 ## Don't see your question?
 
-If your question is about Hubs, check out the [Hubs FAQ](./hubs-cloud-faq.md) or email hubs@mozilla.com.
+If your question is about Hubs, check out the [Hubs FAQ](./hubs-faq.md).
 
-If your question is about deploying Hubs Cloud to AWS, check out the [AWS Troubleshooting Guide](./hubs-cloud-aws-troubleshooting.md)
+If your question is about deploying Hubs Cloud to AWS, check out the [AWS Troubleshooting Guide](./hubs-cloud-aws-troubleshooting.md).
+
+If you can't find what you need in the rest of the documentation, see the [help page](./help.html) for ways to get in touch.

--- a/docs/hubs-faq.md
+++ b/docs/hubs-faq.md
@@ -123,16 +123,16 @@ You can't run custom code in the main Hubs website (hubs.mozilla.com) but you ca
 For more information, see our documentation on [custom clients](./hubs-cloud-custom-clients.html)
 
 ## Can I pay Mozilla to do X, Y, Z?
-It's not possible to pay Mozilla for custom work, however, our code is open source and we welcome external contributors in [GitHub](http://github.com/mozilla/hubs). You can post in the #work-for-hire channel of our Discord if you are interested in paying someone to build something for you.
+It's not possible to pay Mozilla for custom work, however, our code is open source and we welcome external contributors in [GitHub](http://github.com/mozilla/hubs). You can post in the #work-for-hire channel of our [Discord chat server](https://discord.gg/wHmY4nd) if you are interested in paying someone to build something for you.
 
 ## Can I run my virtual event in hubs?
 Yes, check out the information [here](./intro-events.html) for more information on how to get started: 
 
-If you have questions about whether Hubs will be a good fit for your event, drop by our office-hours or meetup to speak to  a member of our team. See our community Discord for the schedule.
+If you have questions about whether Hubs will be a good fit for your event, drop by our office-hours or meetup to speak to  a member of our team. See our community [Discord chat server](https://discord.gg/wHmY4nd) for the schedule.
 
 ## Have you considered adding feature X? 
 
-We keep track of bugs and feature requests in GitHub. If there is a feature you would like, see if someone has already mentioned it in our [list of bugs/feature requests](https://github.com/mozilla/hubs/issues) if you find someone else has already asked for the feature- let us know in a comment that you would like it too. If not, feel free to submit a "feature request." Note, please include as much detail as possible to feature requests to let us know how you see this feature benefiting your use case.
+We keep track of bugs and feature requests in GitHub. If there is a feature you would like, see if someone has already mentioned it in our [list of bugs/feature requests](https://github.com/mozilla/hubs/issues) if you find someone else has already asked for the feature, let us know in a comment that you would like it too. If not, feel free to submit a "feature request." Note, please include as much detail as possible to feature requests to let us know how you see this feature benefiting your use case.
 
 ## Need help with something else?
 

--- a/docs/hubs-faq.md
+++ b/docs/hubs-faq.md
@@ -136,4 +136,4 @@ We keep track of bugs and feature requests in GitHub. If there is a feature you 
 
 ## Need help with something else?
 
-Let us know! hubs@mozilla.com
+If you can't find what you need in the rest of the documentation, see the [help page](./help.html) for ways to get in touch.

--- a/docs/hubs-troubleshooting.md
+++ b/docs/hubs-troubleshooting.md
@@ -73,4 +73,4 @@ YouTube videos don't work reliably in Hubs. We recommend trying Vimeo or saving 
 
 ## Need help with something else?
 
-We have an active Discord Server where you can speak directly to the Hubs team and see what community members are working on. Follow this link to join: [discord.gg/wHmY4nd](https://discord.com/invite/wHmY4nd).
+If you can't find what you need in the rest of the documentation, see the [help page](./help.html) for ways to get in touch.

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -26,7 +26,38 @@ function Help(props) {
           <header className="postHeader">
             <h1>Can't find what you're looking for?</h1>
           </header>
-          <p>Join our <a href="https://discordapp.com/invite/wHmY4nd">Discord Server</a> to chat with our development team, or send an email to <a href="mailto:hubs@mozilla.com">hubs@mozilla.com</a></p>
+
+          <p>
+            If our <a href="/docs/">documentation</a> doesn't answer your questions,{" "}
+            here are a few options for contacting us:
+          </p>
+
+          <strong>Bug Reports and Feature Requests</strong>
+          <p>
+            We track bugs and features on GitHub.
+            You can <a href="https://github.com/mozilla/hubs/issues">view existing tickets,</a>{" "}
+            or open a <a href="https://github.com/mozilla/hubs/issues/new/choose">new issue or feature request</a>.
+          </p>
+
+          <strong>Discussions</strong>
+          <p>
+            If you want to discuss a topic with the Hubs team or the community, or you need help with{" "}
+            troubleshooting, you can browse our GitHub{" "}
+            <a href="https://github.com/mozilla/hubs/discussions">discussion board</a>, or{" "}
+            <a href="https://github.com/mozilla/hubs/discussions/new">start a new discussion</a>.
+          </p>
+
+          <strong>Community Chat</strong>
+          <p>
+            Prefer to chat in real time? Visit our{" "}
+            <a href="https://discord.gg/wHmY4nd">Discord chat server</a>.
+          </p>
+
+          <strong>Email</strong>
+          <p>
+            If you need to share sensitive information in order to get help, you can email us at{" "}
+            <a href="mailto:hubs@mozilla.com">hubs@mozilla.com</a>.
+          </p>
         </div>
       </Container>
     </div>


### PR DESCRIPTION
Moving individual links to discord and email addresses to a centralized help page with links to everything.