### PR TITLE
Correct typos in Spoke-Architecture-Kit.md

### DIFF
--- a/docs/spoke-architecture-kit.md
+++ b/docs/spoke-architecture-kit.md
@@ -3,7 +3,7 @@ id: spoke-architecture-kit
 title: Architecture Kit
 ---
 
-With the launch of the Architecture Kit, creators now have an additional way to build custom content for their 3D scenes without using an external tool. The Architecutre Kit is designed to make it easier to take existing components that have already been optimized for VR and make it easy to configure those pieces to create original models and scenes. 
+With the launch of the Architecture Kit, creators now have an additional way to build custom content for their 3D scenes without using an external tool. The Architecture Kit is designed to make it easier to take existing components that have already been optimized for VR and make it easy to configure those pieces to create original models and scenes. 
 
 This kit contains over 400 different pieces that are designed to be used together to create buildings - the collection includes wall, floor, ceiling, and roof pieces, as well as windows, trim, stairs, and doors. 
 
@@ -21,17 +21,17 @@ Drag and drop the components from the asset panel into your scene. Change the te
 
 ## Making kit pieces double sided
 
-After placing objects in the room, you may notice that they dissappear depending on what direction you are looking at the from. This is because all the objects are single sided, which helps improve performance. It also allows creators to have one side of a wall use a different material than the other side, for example, an interior painted wall and and exterior wall with brick. If you would like to make your wall double sided, copy (ctrl+c, command+c) and paste (ctrl+v, cmmd+v) the object, and then press the Q or E key twice to rotate it 180 degrees. 
+After placing objects in the room, you may notice that they dissappear depending on what direction you are looking at them from. This is because all the objects are single sided, which helps improve performance. It also allows creators to have one side of a wall use a different material than the other side, for example, an interior painted wall and and exterior wall with brick. If you would like to make your wall double sided, copy (ctrl+c, command+c) and paste (ctrl+v, cmmd+v) the object, and then press the Q or E key twice to rotate it 180 degrees. 
 
 ## Adding trim
 
-By default kit pieces like walls don't connect in the corners, particular exterior corners. You might find there is a narrow gap. These spots are are designed to fit trim pieces. 
+By default kit pieces like walls don't connect in the corners. You might find there is a narrow gap in particular exterior corners. These spots are are designed to fit trim pieces. 
 
 ![Spoke Properties Panel](img/spoke-architecture-kit-trim.png)
 
 ## Examples of rooms built with the architecture kit
 
-The following are just a few examples of scenes created using the architecture kid
+The following are just a few examples of scenes created using the architecture kit
 * [Hubs Commons](https://hubs.mozilla.com/scenes/T5QUL3L/hubs-commons) 
 * [Catacomb](https://hubs.mozilla.com/scenes/kDTJ34d/catacomb)
 * [Spiral Tower](https://hubs.mozilla.com/scenes/uNVZeKd/spiral-tower)


### PR DESCRIPTION
- Fixed misspelling of architecture in 2nd sentence
- Adjusted Adding Trim paragraph for easier comprehension
- Fixed misspelling of kit in last sentence