### PR TITLE
Add  Note and future link for Hubs Community Edition

### DIFF
--- a/docs/hubs-cloud-intro.md
+++ b/docs/hubs-cloud-intro.md
@@ -22,3 +22,5 @@ sidebar_label: Introduction
 - Run a custom version of the software to add features and functionality.
 
 **Currently, Hubs Cloud is offered on AWS and DigitalOcean.**
+
+**Note: If you're looking for community Edition, which is the replacement for hubs cloud that you can bring anywhere as a dev, read [Hubs Community Edition](./hubs-community-edition-intro.md)**


### PR DESCRIPTION
This is here to avoid confusion between the hubs Cloud, the Professional Plan and the Community Edition