### PR TITLE
WIP: Add docker-compose.yml and fix nginx paths for resources (Issue #211)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' && github.repository == 'Hubs-Foundation/hubs-docs' }}
         env:
           source: build/hubs-docs/
-          dest: webcontainers@web-containers.hubsfoundation.org:wordpress/hubs-docs
+          dest: webcontainers@hubsfoundation.org:wordpress/hubs-docs
         run: |
           env
           mkdir -p ~/.ssh

--- a/docs/intro-events.md
+++ b/docs/intro-events.md
@@ -74,5 +74,5 @@ We also recommend adding an image to your event rooms that includes a link to yo
 
 <!-- If you are requesting support from Hubs-Foundation to promote or assist with running your event, a code of conduct link is required. -->
 
-<!-- ## More Information
-If you have additional questions about hosting events or conferences using Hubs, please get in touch by [filling out the Hubs event interest form](https://airtable.com/shrAtlBbxEKkLbMsd) or join the [Hubs Community Discord Server](https://discord.gg/wHmY4nd), and check out the #conferences channel. -->
+## More Information
+If you have additional questions about hosting events or conferences using Hubs please join the [Hubs Community Discord Server](https://discord.gg/wHmY4nd)


### PR DESCRIPTION
## What?

Allows a user to locally build and run a docker container hosting the documentation webserver

## Why?

Makes it easy to build and run the documentation server locally without making host OS changes

## Examples

## How to test

`docker compose build`
`docker compose up`

Then browse to localhost:8080/docs

*NOTE* I don't know if these changes break the CI deployment to the official server

## Documentation of functionality

N/A

## Limitations

Might impact CI deployment

## Alternatives considered

## Open questions

Does this impact CI deployment

## Additional details or related context
