### PR TITLE
Spoke Assets UI: Adds Icosa Gallery and extends notes on Sketchfab

### DIFF
--- a/docs/spoke-user-interface.md
+++ b/docs/spoke-user-interface.md
@@ -110,7 +110,7 @@ The models from Google Poly are available, and newer ones can be uploaded.
 The Poly models lean toward low-poly and small textures, and usually perform well.
 
 The search function in Spoke filters for GLTF/GLB files of no more than medium complexity and a license that allows remixing.
-Thus, some models won't be displayed, that can be found searching [Icosa Gallery](https://icosa.gallery/) directly.
+Thus, some models  that can be found when searching [Icosa Gallery](https://icosa.gallery/) directly won't be displayed here.
 
 #### Bing Images
 > This has not yet been implemented for Hubs Cloud Community Edition.


### PR DESCRIPTION
## What?
For the Spoke Assets Panel,
1. Adds notes on Icosa Gallery
2. Clarifies and extends notes on Sketchfab


## Why?
1. To call the attention of new creators to the existing collections
2. To explain why some models visible on Icosa & Sketchfab are not listed in Spoke


## Limitations
I haven't updated notes on other asset sources, as I'm not clear what filtering they do (if any).

## Additional details or related context

