### PR TITLE
Update price with add taxes, RAM choice, typo fix

### DIFF
--- a/docs/beginners-guide-to-CE.md
+++ b/docs/beginners-guide-to-CE.md
@@ -320,7 +320,7 @@ g. For Node plan: Select **$24/month per node** ($0.036/hour) of 4GB total RAM /
 > 💡 Tip: DigitalOcean charges an extra $12/month for mandatory load balancing.<br>
 So a $24 choice here will be $24 + $12 a month for a total of $36 a month.
 
-> 🤔 Advice: If you are using another hosting service that is *not* DigitalOcean, see our FAQ [Can I select a lower price, smaller vCPU Node plan with DigitalOcean?](https://docs.hubsfoundation.org/beginners-guide-to-CE.html#Can-I-select-a-lower-price-smaller-vCPU-Node-plan-with-DigitalOcean) for our advice about selecting node and memory plans.
+> 🤔 Advice: See our FAQ [Can I select a lower price, smaller RAM/vCPU Node plan with DigitalOcean?](./faq.md#can-i-select-a-lower-price-smaller-ramvcpu-node-plan-with-digitalocean) for our further advice about selecting node and memory plans.
 
 h. For Nodes: Select **the negative sign to reduce this from 3 to 1**.
 


### PR DESCRIPTION
## What?
Adds wording in the 'What you will get' and 'How much will this cost' sections to advise that some locations have tax added. 
Link to DO estimated tax rates included.  Example of 20% added VAT described. At Step 5, adds advice that DO customers could pick lower price plans with 2 and 1 vCPUs if their planned use of Hubs is for small groups.  Adds "in the" to the wording in Step 13, g.

## Why?
We've had valued Hubs community members run into the unexpected price per month increased by VAT. This wording advises of that possibility. It mentions the UK example for 2 reasons:
1) Hubs community members in the UK is not unusual at all, so we want to address their concerns. 
2) It explains that the $38/month expectation would actually be $46/month if the taxes are 20%. So this makes the added tax example more concrete.

Fore the RAM additions, this was the result of group testing that was reported in Discord within the past year (https://discord.com/channels/498741086295031808/535606666708910101/1437389788754874460).

Typo was merely spotted in the normal course of business.

## Limitations
First draft of changes. Suggestions welcome.


## Alternatives considered
We could not mention added taxes, but then we will risk surprising members of our Community with larger than expected
monthly bills. This might create bad will with folks that are already looking for a low-price way to host Hubs CE.


## Open questions
Please check for typos in what I typed for the Node plans.

## Additional details or related context
FAQ parallel changes are in PR #238

As of December 22, 2025, these are the pricing choices I see (US-based) for Kubernetes nodes (Droplets) at DigitalOcean: 
![all DO vCPU and memory options as of Dec 22 2025](https://github.com/user-attachments/assets/8d4d076a-969e-4fa6-840a-2691512b0de7)



