### PR TITLE
Add taxes and RAM Node plan options to DO section

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -76,7 +76,7 @@ Note: the metrics are provided by metrics-server
 
 #### CPU/RAM usage for the entire node
 
-idle usage (no users - cache cleared beforehand for more accurate RAM reporting):
+Minimum resource usage to run Hubs (no users - cache cleared beforehand for more accurate RAM reporting):
 | Used millicores | Used RAM |
 | --------------: | -------: |
 |            112m |   1513Mi |


### PR DESCRIPTION
## What?
Adds wording about taxes to the 'Why do the instructions say US$38 per month minimum?' question. Adds new FAQ
'Can I select a lower price, smaller vCPU Node plan with DigitalOcean?'' Small removal of wording that said that the $24/month was DO's lowest price plan, as these changes conflict that now.

## Why?
Both suggested changes are in the Beginner's Guide and need to be reflected in the FAQs. Added wording is almost exactly the same.

## Limitations
Does not define "large" and "small" groups.


## Alternatives considered
Could leave FAQs unchanged but then if the Beginner's Guide edits are accepted, these DigitalOcean questions would look odd.


## Open questions
None.


## Additional details or related context
See PR #237 for the changes to the Beginner's Guide.

