### PR TITLE
Changes firewall UDP range to 40000–65535 in Beginner's Guide

### DIFF
--- a/docs/beginners-guide-to-CE.md
+++ b/docs/beginners-guide-to-CE.md
@@ -819,7 +819,7 @@ ii. Second rule
 iii. Third rule
 1. For Type, select **Custom**.
 2. For Protocol: select **UDP**
-3. For Port Range: enter **35000-60000**
+3. For Port Range: enter **40000-65535**
 4. For Sources: leave as default (All IPv4 and AllIPv6)
 
 ![Capture from DigitalOcean, Networking, Create Firewall page. For Inbound Rules, values entered for TCP Port 4443, TCP Port 5329, and UDP Ports 35000-60000.](img/beginnersguide/image107.png)


### PR DESCRIPTION
## What?
Changes firewall UDP range to 40000–65535 in Beginner's Guide

## Why?
1. Dialog appears to use ports 40000–49999: https://github.com/search?q=repo%3AHubs-Foundation%2Fdialog+40000&type=code
2. Coturn appears to use ports 49152–65535: https://github.com/Hubs-Foundation/coturn/blob/4722697645cf033de8cf4f34e4214af750746365/README.turnserver#L375
3. Not clear what would use ports 35000–39999.
4. Testing showed that Firefox requires UDP ports down to 40000 to be open to avoid certain errors.

## Examples


## Documentation of functionality
No change in functionality

## Open questions
There are issues that claim other ports need to be open in the firewall.
