### PR TITLE
Docs: remove localhost links in setup-updating

### DIFF
--- a/docs/setup-updating.md
+++ b/docs/setup-updating.md
@@ -15,9 +15,9 @@ _This guide walks you through the process of updating and cancelling your subscr
 
 ## Upgrading Your Subscription
 
-You can easily upgrade your Starter Hub to a paid plan at any time. The easiest way is through the Upgrade button on the subscription dashboard, which will then follow the same process as [creating a new paid subscription](http://localhost:3000/docs/setup-creating.html#how-to-subscribe---paid-plans).
+You can easily upgrade your Starter Hub to a paid plan at any time. The easiest way is through the Upgrade button on the subscription dashboard, which will then follow the same process as [creating a new paid subscription](./setup-creating.html#how-to-subscribe---paid-plans).
 
-[<img src="img/upgrade-button.png" alt="The subscription dashboard">](http://localhost:3000/docs/setup-creating.html#how-to-subscribe---paid-plans)
+[<img src="img/upgrade-button.png" alt="The subscription dashboard">](./setup-creating.html#how-to-subscribe---paid-plans)
 
 ## Cancelling Your Subscription
 


### PR DESCRIPTION
## What?
Replaces dev-only `http://localhost:3000/...` links in `docs/setup-updating.md` with the correct relative docs link (`./setup-creating.html#how-to-subscribe---paid-plans`).

## Why?
The `localhost:3000` URLs are only valid in a specific local dev setup and can break or confuse readers on the published docs site. Relative links work in all environments.

## Limitations
- Only updates `docs/setup-updating.md`.
- Does not change other localhost references elsewhere unless they are similarly dev-only URLs.

## Alternatives considered
- Leaving the localhost URLs: risks broken links for most readers.
- Converting to full production URLs: works, but bakes in domain and is less portable than relative links.

## Open questions
- None.
