### PR TITLE
Docs/clarify email faq

### DIFF
--- a/docs/dev-client-gameplay.md
+++ b/docs/dev-client-gameplay.md
@@ -72,8 +72,7 @@ choices. Our choices should not be interpreted fanatically.
 We need to store game state somehow, and conventions are useful. We use
 `Three.js`, which means a lot of game state is stored in various `Object3D`
 subtypes. We store the rest in `bitECS` entities and components, or `map` s
-from entity to struct in cases where `bitECS` components won&rsquo;t do.
-Refer to [this section for this design decision](#avoid-duplicating-state).
+from entity to struct in cases where `bitECS` components won&rsquo;t do. Refer to the section on [Avoid duplicating state](#avoid-duplicating-state) for more details. 
 
 In other words, our game state is not &ldquo;purely&rdquo; in ECS, nor do we
 care to make it so. The PR linked above states the (relatively humble) goals
@@ -249,11 +248,9 @@ function xxx(world: HubsWorld) {
 }
 ```
 
-(`addObject3DComponent` will be explained in [the later sections](#entitydef-jsx-prefab).)
+(`addObject3DComponent` will be explained in the section on [EntityDef / JSX prefab](#entitydef-jsx-prefab).)
 
-If you want to allow your custom components to be created from `JSX` and/or
-`glTF`, you also need to edit the core `src/utils/jsx-entity.ts` file for a
-mapping from their key in the inflator. It will be explained later
+If you want to allow custom components to be created from JSX or glTF, edit the core `src/utils/jsx-entity.ts` file to map the component key to its inflator. It will be explained later
 [Entitydef JSX prefab](#entitydef-jsx-prefab) and [Inflators for glTF](#inflators-for-gltf) for each.
 
 TODO: Write an outline of concepts in the form of an example before breaking

--- a/docs/dev-client-gameplay.md
+++ b/docs/dev-client-gameplay.md
@@ -254,7 +254,7 @@ function xxx(world: HubsWorld) {
 If you want to allow your custom components to be created from `JSX` and/or
 `glTF`, you also need to edit the core `src/utils/jsx-entity.ts` file for a
 mapping from their key in the inflator. It will be explained later
-[here](#entitydef-jsx-prefab) and [here](#inflators-for-gltf) for each.
+[Entitydef JSX prefab](#entitydef-jsx-prefab) and [Inflators for glTF](#inflators-for-gltf) for each.
 
 TODO: Write an outline of concepts in the form of an example before breaking
 down the individual concepts.

--- a/docs/hubs-cloud-aws-known-issues.md
+++ b/docs/hubs-cloud-aws-known-issues.md
@@ -5,6 +5,6 @@ sidebar_label: Known Issues
 description: Some known issues that you might encounter with Hubs Cloud on AWS and how to solve them.
 ---
 
-#### I get the error "Value for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: X, Y
+## I get the error "Value for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: X, Y
 
 This is a known issue with AWS. See: https://github.com/widdix/aws-cf-templates/issues/36. To fix it, you will need to adjust the "Subnet Availability Zones" values in the 'Advanced' section to select an alternative Subnet configuration that matches X, Y and try again.

--- a/docs/hubs-cloud-aws-quick-start.md
+++ b/docs/hubs-cloud-aws-quick-start.md
@@ -65,6 +65,6 @@ description: A brief guide on how to get your Hubs Cloud instance up and running
 
 **Congrats you've successfully set everything up!**
 
-#### Any issues deploying?
+### Any issues deploying?
 
 Check out [AWS Troubleshooting](./hubs-cloud-aws-troubleshooting.md) for solutions to common problems.

--- a/docs/hubs-faq.md
+++ b/docs/hubs-faq.md
@@ -136,7 +136,7 @@ Hubs rooms can only be accessed by individuals with the URL.
 It's not possible to pay Hubs-Foundation for custom work, however, our code is open source and we welcome external contributors in [GitHub](http://github.com/Hubs-Foundation/hubs). You can post in the #work-for-hire channel of our [Discord chat server](https://discord.gg/wHmY4nd) if you are interested in paying someone to build something for you.
 
 ## Can I run my virtual event in Hubs?
-Yes, check out the information [here](./intro-events.html) for more information on how to get started: 
+Yes - see [Hosting Events in Hubs](./intro-events.html) for more information on how to get started: 
 
 If you have questions about whether Hubs will be a good fit for your event, drop by our office-hours or meetup to speak to  a member of our team. See our community [Discord chat server](https://discord.gg/wHmY4nd) for the schedule.
 

--- a/docs/hubs-room-settings.md
+++ b/docs/hubs-room-settings.md
@@ -58,7 +58,7 @@ To temporarily kick a user from the room, open the avatar menu and select "Kick.
 
 When you create a room in Hubs, it is private by default. Sharing the link or access code with other people allows them to enter that specific room, so generally, you want to be careful with who has the link.  
 
-You can link a Hubs room to a channel in a Discord server and have your server members join with their Discord accounts. Banning a user from your server or removing them from the Discord channel will prevent them from being able to re-join the linked Hubs room, even if that user still has the link to the room. You can learn more about the Hubs Discord bot [here](./hubs-discord-bot.html). 
+You can link a Hubs room to a channel in a Discord server and have your server members join with their Discord accounts. Banning a user from your server or removing them from the Discord channel will prevent them from being able to re-join the linked Hubs room, even if that user still has the link to the room. You can learn more in the [Hubs Discord bot documentation](./hubs-discord-bot.html). 
 
 ## Favorite Rooms
 

--- a/docs/setup-configuring-content.md
+++ b/docs/setup-configuring-content.md
@@ -80,7 +80,7 @@ It is important to note that only a few url types are supported by the import to
 
 The Admin Panel is used to manage any scenes or avatars that have been uploaded to your hub. In the left-hand toolbar, you can see eight tabs corresponding to scenes and avatars...
 
-<img src="img/admin-tabs.png" alt="The default avatars">
+<img src="img/admin-tabs.png" alt="Admin panel tabs for scenes and avatars">
 
 Each of these tabs filters assets based on their state and tags. At the top of each tab, you can search by id or name to see if any assets are included in that category.
 

--- a/docs/setup-configuring-content.md
+++ b/docs/setup-configuring-content.md
@@ -62,7 +62,7 @@ It is important to note that only a few url types are supported by the import to
 - Hosted Scene Urls (ex. hyourdomain.com/scenes/Rpt8DJS)
 - Hosted .pack files (ex. raw.githubusercontent.com/hubs/master/asset-packs/avatars-animals.pack)
 
-#### How to Use the "Import Content" Tool
+### How to Use the "Import Content" Tool
 
 <!-- <video loop muted controls >
   <source src="img/import-content.mp4" type="video/mp4">
@@ -86,7 +86,7 @@ Each of these tabs filters assets based on their state and tags. At the top of e
 
 <img src="img/search-bar.png" alt="The default avatars">
 
-#### Asset State
+### Asset State
 
 Asset State is the primary method of controlling a piece of media's discoverability. An asset can have any of four states...
 
@@ -103,7 +103,7 @@ By default, any assets uploaded by users who select "Allow Hubs to promote my sc
 
 Any assets uploaded via the admin panel are automatically assigned the "Active" state, including them in the "Approved" tab and making them discoverable to other users.
 
-#### Asset Tags
+### Asset Tags
 
 Asset tags allow you to control how discoverable an "Active" asset is. To edit tags, an asset's state must be "Active", including the asset in the "Approved" tab of the admin panel. There are three tags you can add to an asset...
 
@@ -115,13 +115,13 @@ Asset tags are case-sensitive, so be sure to use the exact spelling and capitali
 
 <img src="img/tags-examples.png" alt="Examples of tags applied to avatars">
 
-#### Asset Order
+### Asset Order
 
 Assets with the "Featured" tag can be given an order number to control the sequence in which they are displayed to users browsing for scenes and avatars. Order filters from low-to-high, meaning any asset with the order number "1" will be displayed first. Two assets can be given the same order number; if two assets have the same order number, the most recently uploaded asset will display first.
 
 <img src="img/order-example.png" alt="Order control form">
 
-#### Asset Description and Attribution
+### Asset Description and Attribution
 
 To properly describe and credit creators of a certain asset, you can add in description and attribution details that will display whenever a user is encountering that asset.
 
@@ -141,7 +141,7 @@ In addition to regularly checking your usage limit, there are a number of featur
 
 You can also lower your content storage by removing unwanted assets in Spoke and the Admin Panel. PLEASE NOTE: When removing assets with the following methods, it may take up to 3-days for your subscription dashboard to update your content usage.
 
-#### Deleting Assets In Spoke
+### Deleting Assets In Spoke
 
 Assets in Spoke are associated with individual email accounts (you will not be able to delete the assets of another user if you do not have access to their email account).
 
@@ -153,7 +153,7 @@ Assets in Spoke are associated with individual email accounts (you will not be a
 
 <img src="img/delete-asset.png" alt="Deleting assets in spoke">
 
-#### Deleting Assets In The Admin Panel
+### Deleting Assets In The Admin Panel
 
 1. **Navigate to the "Scenes" or "Avatars" tabs in the left-hand toolbar.**
 2. **Click "Edit" on any avatar or scene you wish to remove and set its State to "Removed".**
@@ -170,7 +170,7 @@ The Accounts tab of the Admin Panel indexes all users who have signed-in to your
 
 <img src="img/accounts-screen.png" alt="Deleting assets in spoke">
 
-#### Adding Admin Accounts
+### Adding Admin Accounts
 
 If the account you wish to promote has not yet been created, use the create account form to create a new account with the user's email.
 
@@ -191,7 +191,7 @@ If the account you wish to promote has already been created, use thefind account
 </video>
 <br></br>
 
-#### Identities
+### Identities
 
 _Identities is a deprecated method for associating an account with a username. This feature is functional, but should not be utilized._
 
@@ -221,7 +221,7 @@ In the "Themes" tab, you are able to upload your own JSON theme-ing object to fu
 
 App Settings allow you to control the default behavior, settings, and permissions of your hub and its user interface.
 
-#### Translations (site identification)
+### Translations (site identification)
 
 | Setting          | Description                                                                                                    |
 | ---------------- |----------------------------------------------------------------------------------------------------------------|
@@ -233,7 +233,7 @@ App Settings allow you to control the default behavior, settings, and permission
 | Contact Email    | The email listed on the static page displayed when a room owner closes the room                                |
 | Community Prompt | _This feature is deprecated and should not be utilized._                                                       |
 
-#### Features
+### Features
 
 | Setting               | Description                                                                                                                                                                                         |
 | --------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -255,7 +255,7 @@ App Settings allow you to control the default behavior, settings, and permission
 | Lobby Ghosts          | Allows users who choose "Spectate" when entering room to move throughout the space as an invisible listener.                                                                                        |
 | Public API Access     | Allows admins to create API tokens and submit requests to [the Hubs API](https://www.youtube.com/watch?v=1J84biwO_bk).                                                                              |
 
-#### Rooms
+### Rooms
 
 | Setting                  | Description                                                                                                                 |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
@@ -265,11 +265,11 @@ App Settings allow you to control the default behavior, settings, and permission
 | Default Room Size        | The default room size of newly created room urls.                                                                           |
 | Maximum Room Size        | The maximum room size allowed across your application. This feature is an important tool to manage your server's CCU limit. |
 
-#### Links
+### Links
 
 These URLs correspond to the links enabled in the "Features" tab of App Settings.
 
-#### Auth
+### Auth
 
 | Setting                  | Description                                                       |
 | ------------------------ | ----------------------------------------------------------------- |

--- a/docs/setup-custom-client.md
+++ b/docs/setup-custom-client.md
@@ -19,7 +19,7 @@ _This guide walks you through the steps of setting up and removing a custom clie
 
 ## Introduction
 
-Deploying a custom client to your Hub allows you to fully control the appearance and functionality of [the Hubs 3D engine and frontend code](https://github.com/mozilla/hubs). This feature is intended for subscribers with at least a beginner level of javascript development experience. Please be advised that deploying a custom client disables the automatic updates that the Hubs Team regularly deploys to subscription instances. You can follow our regular updates [here](https://github.com/mozilla/hubs/releases).
+Deploying a custom client to your Hub allows you to fully control the appearance and functionality of [the Hubs client source code](https://github.com/mozilla/hubs). This feature is intended for subscribers with at least a beginner level of javascript development experience. Please be advised that deploying a custom client disables the automatic updates that the Hubs Team regularly deploys to subscription instances. You can follow our regular updates in [Hubs GitHub Releases](https://github.com/mozilla/hubs/releases).
 
 If you need more assistance, we recommend following along with our [Custom Client Tutorial Video](https://www.youtube.com/watch?v=dJAy1gk5Ow0).
 


### PR DESCRIPTION
## What?
Addresses issue #262. In this PR, w clarity the FAQ entry "I need more than 300 emails per month."

In this change, we restructure the section to clearly epxlain Scaleway email limits and how users can increase their quota. 

## Why?
The previous version was v difficult to follow and understand, as it had multiple quota tiers that were combined into a single paragraph, making it unclear how the email limits scale. 

## Examples
Documentation only.

## How to test
Documentation only.

## Documentation of functionality
Documentation only.

## Limitations
Just wanted to gently point out that thsi update focuses only on the Scaleway-based setup described in the guide. It does not include the expanded coverage to other SMTP providers in detail. 

## Alternatives considered
I'd consider keeping hte original paragraph structure with minor wording edits, but restructuring into bullet points for better readability and clarity. 

## Open questions
None.


## Additional details or related context
This is a documentation-only change intended to improve usability and reduce confusion for users configuring email in Hubs Community Edition. 