### PR TITLE
Removes mention of the color green for commenting

### DIFF
--- a/docs/beginners-guide-to-CE.mdx
+++ b/docs/beginners-guide-to-CE.mdx
@@ -466,7 +466,7 @@ For example: `doctl auth init --context MyHubsCE`
 
 b. The terminal will prompt `> Enter your access token:`  **Paste in the DO API token.** Hit enter on your keyboard.
 
-☑️ Green check mark means success!
+☑️ Check mark means success!
 
 ![Capture of VS Code notification screen with text "Validating your token..." with a green check mark.](img/beginnersguide/image67.png)
 

--- a/docs/beginners-guide-to-CE.mdx
+++ b/docs/beginners-guide-to-CE.mdx
@@ -752,7 +752,7 @@ d. Select **Control + F** on your keyboard and search for this text: **default-s
 
 ![Capture from VS code, center code panel. After searching on "default-ssl-certificate" line, the line containing that code is highlighted.](img/beginnersguide/image96.png)
 
-e. Enter a # (number sign) at the beginning of the text line, to the left of the dashes. It will be correct if the line turns green; this means the line has been disabled.
+e. Enter a # (number sign) at the beginning of the text line, to the left of the dashes. It will be correct if the line changes color; this means the line has been disabled.
 
 ![Capture from VS code, center code panel. After searching on "default-ssl-certificate" line, adding a number sign turned the line from orange to green showing that the default certificates are now disabled.](img/beginnersguide/image97.png)
 

--- a/docs/whats-next.mdx
+++ b/docs/whats-next.mdx
@@ -214,7 +214,7 @@ Updating your Hubs deployment scripts from the repository at Github (the zip fil
 
 * In VS Code, select **hcce.yaml**
 * Select **Control + F** on your keyboard and search for this text: **default-ssl-certificate.**
-* Enter a # (number sign) at the beginning of the text line, to the left of the dashes. It will be correct if the line turns green; this means the line has been disabled.
+* Enter a # (number sign) at the beginning of the text line, to the left of the dashes. It will be correct if the line changes color; this means the line has been disabled.
 * Select **File, Save**. This will keep all of the changes you just made.
 * Now we need to apply your changes to Kubernetes on DO. **Copy and paste or type** this into the terminal and **hit enter on your keyboard**
 


### PR DESCRIPTION
## What?
Replaces wording of the color change in VS code that specified the color green with a generic reference to look for a color change. Changes in 3 places: 

1. Beginners Guide, Step 15, e.
2. In Beginners Guide, 11. Authenticate doctl, b
3. What's next, 'After updating' section, 4th bullet.

## Why?
VS Code update of March 2026 [changed the default color scheme ](https://github.com/microsoft/vscode/issues/293405) and now green might not be the color for comment lines. This wording now by-passes whatever color a user might see as some kind of color change does still occur. It is possible that VS Code will revert their update based on feedback, but this change should sidestep the entire problem.


## Limitations
None

## Alternatives considered
Could leave instructions as is but because we built these specific documents for new VS Code users, they might be unnerved by unexpected color changes that they see that do not match what we describe.  To be fair, this PR only changes the described color, "green". It still _shows_ green in the accompanying images.


## Open questions
~~Did not change the "green" checkmark statement in the Beginner's Guide, 11 b (token verification) because I did not know how the VS Code update impacted a "symbol" color.~~


## Additional details or related context
VS Code updated their default "theme" and commenting no longer is indicated by a green color.  Several users have [complained about the change](https://github.com/microsoft/vscode/issues/304953). 

There is a work around:  File>Preferences>Theme>Color Theme>Dark Modern

The word "green" appears many times in our alt text descriptions of images.  At this time, I don't feel those need changing with this PR as green is the color inside the current images.  

I only checked for the descriptor of green for commenting in the Hubs docs, Setting Up Your Hub section.

I did run npm run start for a preview.

Thank you for comments and review.

