### PR TITLE
docs/community-edition-callout-message

### DIFF
--- a/docs/whats-next.mdx
+++ b/docs/whats-next.mdx
@@ -18,6 +18,7 @@ And this is what you’ll see, the fallback space. It’s gray ground with a dar
 
 Eager to put up a scene? There are Hubs scenes available! Hop down to the [Importing Scenes and Avatars section](#importing-scenes-and-avatars).
 
+
 ## **Where is the Admin Panel?**
 
 It is at your domain address with admin tacked on the end. Like this:
@@ -121,6 +122,13 @@ If you don’t have a friend available, just duplicate the tab, and you will be 
 
 ## **Updating Hubs**
 
+[!IMPORTANT]
+Run the following update commands from the `community-edition` directory of your Hubs CE installation.
+
+If your terminal is not already in that folder, change into it first:
+
+`cd community-edition`
+
 Hubs software is updated from time to time. Announcements will be in the Hubs Discord.
 
 ### How to update your Hubs CE instance
@@ -167,6 +175,10 @@ Updating your Hubs deployment scripts from the repository at Github (the zip fil
 * Delete the old **input-values.yaml** file that is in your Desktop folder.
 
 ### How to update your Hubs CE deployment scripts (Git Version)
+
+> ⚠️ **Important**
+> Run these commands from the `community-edition` folder in your Hubs installation.  
+> If you run them from another directory, the commands may fail or not apply correctly.
 
 * If you are using the master branch with uncommitted changes:
 * Stash your changes by running this command:


### PR DESCRIPTION
## What?
This PR addresses #265.

I have added a clear callout message in the relevant documentation sections to explain that certain commands must be run from the `community-edition` folder in a Hubs CE installation.

## Why?
The current documentation correctly assumes the the  working directory in several places, but this does not clearly state it. So this  can cause users to run commands from the wrong folder, leading to commands failing or not applying correctly.

This update makes that requirement explicit and easier to notice.

## Limitations
This change that is made now focuses on clarifying the working directory requirement in the affected documentation sections. It does not reorganize the broader update or setup documentation.

## Alternatives considered
Embedding the note inline in every command step was considered at one point, but a consistent callout was chosen because it is more visible and avoids repetitive wording. Concise is nice. 

## Open questions
None.

## Additional details or related context
This is a documentation-only change that si intended to reduce a common source of user confusion when  someone is updating updating or maintaining a Hubs Community Edition installation.