### PR TITLE
Mozilla branding removal

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
           def gitSha = sh(returnStdout: true, script: "git log -n 1 --pretty=format:'%h'").trim()
           def text = (
             "*<http://localhost:8080/job/${env.JOB_NAME}/${env.BUILD_NUMBER}|#${env.BUILD_NUMBER}>* *${env.JOB_NAME}* " +
-            "<https://github.com/mozilla/hubs/commit/$gitSha|$gitSha> ${hubsDocsVersion} " +
+            "<https://github.com/Hubs-Foundation/hubs/commit/$gitSha|$gitSha> ${hubsDocsVersion} " +
             "Hubs Docs Pushed: ```${gitSha} ${gitMessage}```\n"
           )
           def payload = 'payload=' + JsonOutput.toJson([

--- a/docs/setup-custom-client.mdx
+++ b/docs/setup-custom-client.mdx
@@ -20,7 +20,7 @@ _This guide walks you through the steps of setting up and removing a custom clie
 
 ## Introduction
 
-Deploying a custom client to your Hub allows you to fully control the appearance and functionality of [the Hubs 3D engine and frontend code](https://github.com/mozilla/hubs). This feature is intended for subscribers with at least a beginner level of javascript development experience. Please be advised that deploying a custom client disables the automatic updates that the Hubs Team regularly deploys to subscription instances. You can follow our regular updates [here](https://github.com/mozilla/hubs/releases).
+Deploying a custom client to your Hub allows you to fully control the appearance and functionality of [the Hubs 3D engine and frontend code](https://github.com/Hubs-Foundation/hubs). This feature is intended for subscribers with at least a beginner level of javascript development experience. Please be advised that deploying a custom client disables the automatic updates that the Hubs Team regularly deploys to subscription instances. You can follow our regular updates [here](https://github.com/Hubs-Foundation/hubs/releases).
 
 If you need more assistance, we recommend following along with our [Custom Client Tutorial Video](https://www.youtube.com/watch?v=dJAy1gk5Ow0).
 
@@ -32,7 +32,7 @@ If you need more assistance, we recommend following along with our [Custom Clien
 
 ## Part A: Set Up the Hubs Client
 
-1. Clone the [Hubs github repository](https://github.com/mozilla/hubs) onto your device. Users deploying custom clients to subscriptions should use the `master` branch of the repository.
+1. Clone the [Hubs github repository](https://github.com/Hubs-Foundation/hubs) onto your device. Users deploying custom clients to subscriptions should use the `master` branch of the repository.
 
 2. Install the project's node dependencies by running `npm ci`. Make sure you are using node version `16.16`. This process may take up to 30 minutes.
 
@@ -57,7 +57,7 @@ If you need more assistance, we recommend following along with our [Custom Clien
 
 ```
 ### done ###
--rw-r--r--@ 1 mozilla staff {timestamp} ./.retpack/retpack.tar.gz
+-rw-r--r--@ 1 username staff {timestamp} ./.retpack/retpack.tar.gz
 ```
 
 &nbsp;&nbsp;&nbsp;<u>**Troubleshooting**</u>
@@ -81,7 +81,7 @@ _Deploying a custom client will disable the automatic updates that the Hubs Team
 
 2. The terminal command may take several minutes to complete depending on the quantity and nature of your customization. **Do not exit the terminal until the upload process has completed.** Once successfully complete, it will return `done, reqId: <unique-ID-string>`. After a few minutes, you should see your customization on your Hub.
 
-3. After deploying, try to create a room to verify your customizations have taken place. If you are unable to see your customizations, email [hubs-feedback@mozilla.com](mailto:hubs-feedback@mozilla.com) with the subject line `Hubs Custom Client Deployment Troubleshooting` and a description of your problem.
+3. After deploying, try to create a room to verify your customizations have taken place. If you are unable to see your customizations, email [info@hubsfoundation.org](mailto:info@hubsfoundation.org) with the subject line `Hubs Custom Client Deployment Troubleshooting` and a description of your problem.
 
 ## Removing Your Custom Client
 

--- a/docs/setup-custom-client.mdx
+++ b/docs/setup-custom-client.mdx
@@ -57,7 +57,7 @@ If you need more assistance, we recommend following along with our [Custom Clien
 
 ```
 ### done ###
--rw-r--r--@ 1 username staff {timestamp} ./.retpack/retpack.tar.gz
+-rw-r--r-- 1 root root {timestamp} ./.retpack/retpack.tar.gz
 ```
 
 &nbsp;&nbsp;&nbsp;<u>**Troubleshooting**</u>

--- a/docs/setup-custom-client.mdx
+++ b/docs/setup-custom-client.mdx
@@ -81,7 +81,7 @@ _Deploying a custom client will disable the automatic updates that the Hubs Team
 
 2. The terminal command may take several minutes to complete depending on the quantity and nature of your customization. **Do not exit the terminal until the upload process has completed.** Once successfully complete, it will return `done, reqId: <unique-ID-string>`. After a few minutes, you should see your customization on your Hub.
 
-3. After deploying, try to create a room to verify your customizations have taken place. If you are unable to see your customizations, email [info@hubsfoundation.org](mailto:info@hubsfoundation.org) with the subject line `Hubs Custom Client Deployment Troubleshooting` and a description of your problem.
+3. After deploying, try to create a room to verify your customizations have taken place. If you are unable to see your customizations, ask for help in the Hubs Foundation Discord with a description of your problem.
 
 ## Removing Your Custom Client
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -4,8 +4,8 @@ pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
 
 pkg_version="1.0.0"
 pkg_license=('MPLv2')
-pkg_description="Docs for Hubs + Spoke by Mozilla"
-pkg_upstream_url="https://hubs.mozilla.com/docs"
+pkg_description="Docs for Hubs + Spoke"
+pkg_upstream_url="https://docs.hubsfoundation.org"
 pkg_deps=(
   core/node10
   core/coreutils

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
 pkg_version="1.0.0"
 pkg_license=('MPLv2')
 pkg_description="Docs for Hubs + Spoke"
-pkg_upstream_url="https://docs.hubsfoundation.org"
+pkg_upstream_url="https://github.com/Hubs-Foundation/hubs-docs"
 pkg_deps=(
   core/node10
   core/coreutils


### PR DESCRIPTION
## What?

This pull request removes  removes several remaining Mozilla-branded repository, package, and support references from hubs-docs.

Changes include:

* Updating repository links from Mozilla-owned repositories to Hubs Foundation repositories where appropriate.
* Updating package metadata that still referenced Mozilla Mixed Reality.
* Updating outdated Mozilla-specific support/contact references.
* Replacing a small number of remaining Mozilla-branded strings that no longer reflect current project ownership.

## Why?

The Hubs Foundation is  continuing the Mozilla Branding Removal effort across Hubs-related repositories.

These references were no longer accurate and could cause confusion about project ownership, support channels, and repository locations.

## Limitations

This pull request intentionally focuses on a small set of clearly outdated branding references. These ones seemed obvious enough to begin some meaningful changes. 

Historical attribution, licenses, contributor information, and references to Mozilla resources that are still relevant (such as MDN documentation) were left unchanged.

More branding cleanup work may remain elsewhere in the repository. Further clarification may be needed for changing email addresses or other official domains. 

## Additional details or related context

This PR is part of the the ongoing Mozilla Branding Removal effort referenced in the Communication & Documentation Team roadmap and Mozilla Branding Removal Guidelines.
