### PR TITLE
Increase publish workflow security and tighten permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build_sync:
     runs-on: ubuntu-latest
@@ -16,9 +18,11 @@ jobs:
         working-directory: ./website
     steps:
       - name: checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
       - name: include dependencies
@@ -30,10 +34,11 @@ jobs:
         env:
           source: build/
           dest: webcontainers@hubsfoundation.org:wordpress/hubs-docs
+          VARS_KNOWN_HOSTS: ${{ vars.KNOWN_HOSTS }}
         run: |
           env
           mkdir -p ~/.ssh
           echo "${{ secrets.WEBCONTAINERS_KEY }}" >  ~/.ssh/WEBCONTAINERS_KEY
           chmod 600 ~/.ssh/WEBCONTAINERS_KEY
-          echo "${{ vars.KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          echo "${VARS_KNOWN_HOSTS}" > ~/.ssh/known_hosts
           rsync -v --rsh='ssh -i  ~/.ssh/WEBCONTAINERS_KEY' --archive --delete-after $source $dest


### PR DESCRIPTION
## What?
<!-- REQUIRED FOR ALL PULL REQUESTS — Explain what your pull request does -->
Sets permissions to none, pins calls to external actions to specific commits, prevents credentials from actions/checkout from persisting, and replaces direct use of the GitHub variables in the shell execution with indirect usage via shell variables.

## Why?
<!-- REQUIRED FOR ALL PULL REQUESTS — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
To minimize the chance of the workflow being hacked or vulnerable to a supply chain hack (pinning the external action calls helps with this), and in preparation to globally restrict permissions for all Hubs Foundation workflows.

According to Zizmor, filtering GitHub variables through environment variables prevents code injection via template expansion.  Essentially, this should ensure an attacker can't manipulate data in GitHub to achieve remote code execution when the workflow is run.


## Examples
<!-- DO NOT INCLUDE FOR HUBS DOCUMENTATION UPDATES — If applicable, give examples of your changes, screenshots, videos, etc. -->
N/A

## How to test
<!-- REQUIRED FOR TECHNICAL PULL REQUESTS; DO NOT INCLUDE FOR HUBS DOCUMENTATION UPDATES — Give the steps required to test your pull request -->

1. The majority of the workflow can be tested by just pushing the changes to a fork and running them.
2. To test the actual publishing:
3. Create a new branch on the Hubs Foundation's repository, ensure it is up-to-date with the latest changes from the master branch, then modify the workflow to allow your new branch to sync, then run the workflow. 
4. See that the workflow runs and completes successfully.

To verify that all the Zizmor issues have been addressed, run the following command from the repository folder and see that Zizmor reports no issues (that we care about) for the publish workflow.
```
docker run --rm --name zizmor -v .:/usr/repo ghcr.io/zizmorcore/zizmor --fix=all /usr/repo
```

## Documentation of functionality
<!-- REQUIRED FOR TECHNICAL PULL REQUESTS; DO NOT INCLUDE FOR HUBS DOCUMENTATION UPDATES — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
This doesn't change the functionality of the workflow, so no documentation update is needed.

## Known limitations
<!-- List anything that isn't addressed, e.g. corner cases, and why they weren't addressed -->
This doesn't update any of the external workflow versions.  I feel it is out of scope for this PR and can/should be done along with all the others in further PRs when addressing GitHub's required update to use Node 24+.

## Alternatives considered
<!-- If there are any alternative ways of implementing this that you thought of, but decided against, list them here along with why they were discarded -->
None.

## Open questions
<!-- List any questions you have -->
None.

## Additional details or related context
<!-- Give any other details that you think the reviewers should be aware of -->
These security improvements were advised by the Zizmor tool and `GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 #v1 Beta 9`

Part of https://github.com/Hubs-Foundation/.github/issues/13